### PR TITLE
Task/dgoa 3438 gradle update!

### DIFF
--- a/extensions/okhttp/build.gradle
+++ b/extensions/okhttp/build.gradle
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-apply plugin: 'com.android.library'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23

--- a/extensions/opus/build.gradle
+++ b/extensions/opus/build.gradle
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-apply plugin: 'com.android.library'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,17 +52,17 @@ android.libraryVariants.all { variant ->
         return; // Skip debug builds.
     }
     def task = project.tasks.create "jar${name.capitalize()}", Jar
-    task.dependsOn variant.javaCompile
-    task.from variant.javaCompile.destinationDir
-    artifacts.add('archives', task);
+    task.dependsOn variant.javaCompileProvider
+    task.from variant.javaCompileProvider.destinationDir
+    artifacts.add('archives', task)
 }
 
 android.libraryVariants.all { variant ->
     task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
         title = "ExoPlayer library"
         description "Generates Javadoc for $variant.name."
-        source = variant.javaCompile.source
-        classpath = files(variant.javaCompile.classpath.files, project.android.getBootClasspath())
+        source = variant.javaCompileProvider.source
+        classpath = files(variant.javaCompileProvider.classpath.files, project.android.getBootClasspath())
         options {
             links "http://docs.oracle.com/javase/7/docs/api/"
             linksOffline "https://developer.android.com/reference","${android.sdkDirectory}/docs/reference"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-apply plugin: 'com.android.library'
+apply plugin: 'com.android.application'
 apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         // Important: ExoPlayerLib specifies a minSdkVersion of 9 because
@@ -25,7 +25,7 @@ android {
         // functionality provided by the library requires API level 16 or
         // greater.
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
 
     buildTypes {


### PR DESCRIPTION
These updates stemmed from upgrading gradle for task/DGOA-3438.

Now compatible with gradle 5 (plug in 3).

Test with: Exoplayer-amazon-port library on branch task/DGOA-3438 - discovery-digital/exoplayer-amazon-port#1

Test with: firetv repo on branch task/DGOA-3438- discovery-digital/discoverygo-firetv#404

Test with: java-discovery-sdk library on branch task/DGOA-3438 - discovery-digital/java-discovery-sdk#65

Test Steps:

Launch app
play a video
general smoke test
